### PR TITLE
feat: support boolean for autoImports option and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,22 @@ To configure Nuxt Query, update your `nuxt.config.ts` specifying the options you
 export default defineNuxtConfig({
   modules: ['@peterbud/nuxt-query'],
   nuxtQuery: {
-    // Specify which Vue Query composable(s) to auto-import
+    /**
+     * Specify which Vue Query composable(s) to auto-import
+     * Default to `false`, set to `true` to auto-import all Vue Query composables
+     */
     autoImports: ['useQuery', 'useMutation'],
 
     // Enable / disable Nuxt DevTools integration (default: true).
     devtools: true,
 
-    // These are the same options as the QueryClient 
-    // from @tanstack/vue-query, will be passed 
-    // to the QueryClient constructor
-    // More details: https://tanstack.com/query/v5/docs/reference/QueryClient
+    /**
+     * These are the same options as the QueryClient 
+     * from @tanstack/vue-query, which will be passed 
+     * to the QueryClient constructor
+     * More details: https://tanstack.com/query/v5/docs/reference/QueryClient
+     */
+    
     queryClientOptions: {
       defaultOptions: {
         queries: {

--- a/src/module.ts
+++ b/src/module.ts
@@ -17,7 +17,7 @@ const _composables = [
 type VueQueryComposables = typeof _composables[number]
 
 export interface ModuleOptions {
-  autoImports: VueQueryComposables[] | false
+  autoImports: VueQueryComposables[] | boolean
   devtools: boolean
   queryClientOptions: QueryClientConfig | undefined
 }
@@ -71,8 +71,17 @@ export default defineNuxtModule<ModuleOptions>({
     addPlugin(resolver.resolve('./runtime/plugin'))
 
     // Auto imports tanstack composables
-    if (options.autoImports && options.autoImports.length > 0)
-      addImports(options.autoImports.map(name => ({ name, from: '@tanstack/vue-query' })))
+    let importComposables = new Set<VueQueryComposables>(_composables)
+    if (typeof options.autoImports === 'boolean') {
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+      !options.autoImports && importComposables.clear()
+    }
+    else {
+      importComposables = importComposables.intersection(new Set(options.autoImports))
+    }
+    addImports([...importComposables.values()].map(name => (
+      { name, from: '@tanstack/vue-query' }
+    )))
 
     if (options.devtools)
       setupDevToolsUI(nuxt, resolver)

--- a/src/module.ts
+++ b/src/module.ts
@@ -77,7 +77,7 @@ export default defineNuxtModule<ModuleOptions>({
       !options.autoImports && importComposables.clear()
     }
     else {
-      importComposables = importComposables.intersection(new Set(options.autoImports))
+      importComposables = new Set(options.autoImports)
     }
     addImports([...importComposables.values()].map(name => (
       { name, from: '@tanstack/vue-query' }


### PR DESCRIPTION
This PR adds support for passing `autoImports: true` in Nuxt module option to have all composables get auto-imported. Meanwhile, the ability to define the subset of composables to auto-import is still preserved, which has been refactored to use JavaScript set for set operation.